### PR TITLE
Fix 'SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode'. Add engines constraint to package.json.

### DIFF
--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const mkdirp = require('mkdirp')
 const fs = require('fs')
 const path = require('path')

--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const mkdirp = require('mkdirp')
 const fs = require('fs')

--- a/lib/symdeps.test.js
+++ b/lib/symdeps.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const proxyquire = require('proxyquire')
 const chai = require('chai')
 const sinon = require('sinon')

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/agarzola/symdeps/issues"
   },
-  "homepage": "https://github.com/agarzola/symdeps#readme"
+  "homepage": "https://github.com/agarzola/symdeps#readme",
+  "engines": {
+    "node": ">=4"
+  }
 }


### PR DESCRIPTION
    >> node -v
    v4.8.7