### PR TITLE
GH-22 Support Relative Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ in the package name). So adding `@project/library` to the path array in the
 examples above would result in a symlink at:
 `project_root/public/js/vendor/library`.
 
+### Using relative links
+This library can generate symbolic links using relative source paths that are
+relative to the location of the link instead of absolute (which is the
+default). This is useful in the creation of deployment artifacts, when using
+container environments where the symlinks may be created outside the container,
+or when otherwise moving the application root somewhere. You can make `symdeps`
+use relative paths by setting `"relative": true` in your `package.json`’s
+symdeps config, or by using the `--relative` flag from the command line.
+
 ### Using hard links
 Depending on your workflow, you might want to use hard links instead of
 symbolic links. This is particularly useful if your deployment process does not
@@ -89,9 +98,3 @@ example), or if you want to track front-end dependencies in version control but
 don’t want to track everything in `node_modules`. You can make `symdeps` create
 hard links by setting `"hard": true` in your `package.json`’s symdeps config,
 or by using the `--hard` flag from the command line.
-
-### Roadmap
-- **Create relative links.** The ability to generate symbolic links whose
-target paths are relative to the location of the link instead of absolute. This
-is useful in the creation of deployment artifacts or when otherwise moving the
-application root somewhere.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ links? That’s cool too.
 
 ### Hang on. My task runner already does this.
 If your task runner’s only role in your workflow is to move files around, you’re
-essentially using a [Jaeger](https://pacificrim.wikia.com/wiki/Jaeger "But when
-you’re in a Jaeger, suddenly, you can fight the hurricane.") to pick up a
-pebble. If you use a task runner to do more than just that, consider whether
-defining a non-standard location for your dependencies should be done in your
+essentially using a [D11 bulldozer](https://en.wikipedia.org/wiki/Caterpillar_D11)
+to move a bucket of dirt. If you use a task runner to do more than just that,
+consider whether declaring where your dependencies live should be done in your
 task runner config or in your package manager config.
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ module.exports = () => {
     return
   }
 
-  config.hard = config.hard || process.argv.indexOf('--hard') > - 1
+  config.hard = config.hard || process.argv.indexOf('--hard') > -1
+  config.relative = config.relative || process.argv.indexOf('--relative') > -1
 
   symdeps(config)
 }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = () => {
   }
 
   config.hard = config.hard || process.argv.indexOf('--hard') > -1
-  config.relative = config.relative || process.argv.indexOf('--relative') > -1
+  config.absolute = config.absolute || process.argv.indexOf('--absolute') > -1
 
   symdeps(config)
 }

--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -22,7 +22,7 @@ module.exports = config => {
 
         // Use relative source path if requested.
         if (config.relative) {
-          source = path.relative(destination, source)
+          source = path.relative(dest_base, source)
         }
       }
 

--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -19,6 +19,11 @@ module.exports = config => {
             return array.length - 1 === i ? segment : ''
           }, '')
         )
+
+        // Use relative source path if requested.
+        if (config.relative) {
+          source = path.relative(destination, source)
+        }
       }
 
       if (!source || !destination) {

--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -12,18 +12,14 @@ module.exports = config => {
     directives.forEach(directive => {
       let source, destination
       if (typeof directive === 'string') {
-        source = path.resolve('node_modules', directive)
+        const absolute_source = path.resolve('node_modules', directive)
+        source = config.absolute ? absolute_source : path.relative(dest_base, absolute_source)
         destination = path.resolve(
           dest_base,
           directive.split(path.sep).reduce((result, segment, i, array) => {
             return array.length - 1 === i ? segment : ''
           }, '')
         )
-
-        // Use relative source path if requested.
-        if (config.relative) {
-          source = path.relative(dest_base, source)
-        }
       }
 
       if (!source || !destination) {

--- a/lib/symdeps.test.js
+++ b/lib/symdeps.test.js
@@ -36,29 +36,35 @@ const config = {
 }
 
 describe('core', () => {
+  const simple_deps_path = 'public/simple_deps'
+  const scoped_deps_path = 'public/scoped_deps'
+  const nested_file_deps_path = 'public/nested_file_deps'
   before(() => symdeps(config))
 
   it('should create a symlink for simple dependency names', () => {
-    config.paths['public/simple_deps'].forEach(dep_name => {
+    config.paths[simple_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve('public/simple_deps', dep_name)
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
+      let expected_dest = path.resolve(simple_deps_path, dep_name)
+      let expected_relative_path = path.relative(simple_deps_path, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
   })
 
   it('should create a symlink for scoped dependency names', () => {
-    config.paths['public/scoped_deps'].forEach(dep_name => {
+    config.paths[scoped_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve(`public/scoped_deps/${dep_name.split('/')[1]}`)
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
+      let expected_dest = path.resolve(`${scoped_deps_path}/${dep_name.split('/')[1]}`)
+      let expected_relative_path = path.relative(scoped_deps_path, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
   })
 
   it('should create a symlink for nested files', () => {
-    config.paths['public/nested_file_deps'].forEach(dep_name => {
+    config.paths[nested_file_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve('public/nested_file_deps/nested_file.js')
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
+      let expected_dest = path.resolve(`${nested_file_deps_path}/nested_file.js`)
+      let expected_relative_path = path.relative(nested_file_deps_path, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
   })
 
@@ -115,8 +121,8 @@ describe('options', () => {
     expect(fs_mock.symlinkSync).to.not.be.called
   })
 
-  it('should use relative paths if indicated via config', () => {
-    optionsConfig.relative = true
+  it('should use absolute paths if indicated via config', () => {
+    optionsConfig.absolute = true
     symdeps(optionsConfig)
     const simple_deps_path = 'public/simple_deps'
     const scoped_deps_path = 'public/scoped_deps'
@@ -126,22 +132,19 @@ describe('options', () => {
     optionsConfig.paths[simple_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
       let expected_dest = path.resolve(simple_deps_path, dep_name)
-      let expected_relative_path = path.relative(simple_deps_path, expected_source)
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
     })
 
     optionsConfig.paths[scoped_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
       let expected_dest = path.resolve(`${scoped_deps_path}/${dep_name.split('/')[1]}`)
-      let expected_relative_path = path.relative(scoped_deps_path, expected_source)
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
     })
 
     optionsConfig.paths[nested_file_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
       let expected_dest = path.resolve(`${nested_file_deps_path}/nested_file.js`)
-      let expected_relative_path = path.relative(nested_file_deps_path, expected_source)
-      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_source, expected_dest)
     })
   })
 })

--- a/lib/symdeps.test.js
+++ b/lib/symdeps.test.js
@@ -114,4 +114,31 @@ describe('options', () => {
     expect(fs_mock.linkSync).to.be.callCount(5)
     expect(fs_mock.symlinkSync).to.not.be.called
   })
+
+  it('should use relative paths if indicated via config', () => {
+    optionsConfig.relative = true
+    symdeps(optionsConfig)
+
+    expect(fs_mock.symlinkSync).to.be.callCount(5)
+    optionsConfig.paths['public/simple_deps'].forEach(dep_name => {
+      let expected_source = path.resolve('node_modules', dep_name)
+      let expected_dest = path.resolve('public/simple_deps', dep_name)
+      let expected_relative_path = path.relative(expected_dest, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+    })
+
+    optionsConfig.paths['public/scoped_deps'].forEach(dep_name => {
+      let expected_source = path.resolve('node_modules', dep_name)
+      let expected_dest = path.resolve(`public/scoped_deps/${dep_name.split('/')[1]}`)
+      let expected_relative_path = path.relative(expected_dest, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+    })
+
+    optionsConfig.paths['public/nested_file_deps'].forEach(dep_name => {
+      let expected_source = path.resolve('node_modules', dep_name)
+      let expected_dest = path.resolve('public/nested_file_deps/nested_file.js')
+      let expected_relative_path = path.relative(expected_dest, expected_source)
+      expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
+    })
+  })
 })

--- a/lib/symdeps.test.js
+++ b/lib/symdeps.test.js
@@ -118,26 +118,29 @@ describe('options', () => {
   it('should use relative paths if indicated via config', () => {
     optionsConfig.relative = true
     symdeps(optionsConfig)
+    const simple_deps_path = 'public/simple_deps'
+    const scoped_deps_path = 'public/scoped_deps'
+    const nested_file_deps_path = 'public/nested_file_deps'
 
     expect(fs_mock.symlinkSync).to.be.callCount(5)
-    optionsConfig.paths['public/simple_deps'].forEach(dep_name => {
+    optionsConfig.paths[simple_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve('public/simple_deps', dep_name)
-      let expected_relative_path = path.relative(expected_dest, expected_source)
+      let expected_dest = path.resolve(simple_deps_path, dep_name)
+      let expected_relative_path = path.relative(simple_deps_path, expected_source)
       expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
 
-    optionsConfig.paths['public/scoped_deps'].forEach(dep_name => {
+    optionsConfig.paths[scoped_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve(`public/scoped_deps/${dep_name.split('/')[1]}`)
-      let expected_relative_path = path.relative(expected_dest, expected_source)
+      let expected_dest = path.resolve(`${scoped_deps_path}/${dep_name.split('/')[1]}`)
+      let expected_relative_path = path.relative(scoped_deps_path, expected_source)
       expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
 
-    optionsConfig.paths['public/nested_file_deps'].forEach(dep_name => {
+    optionsConfig.paths[nested_file_deps_path].forEach(dep_name => {
       let expected_source = path.resolve('node_modules', dep_name)
-      let expected_dest = path.resolve('public/nested_file_deps/nested_file.js')
-      let expected_relative_path = path.relative(expected_dest, expected_source)
+      let expected_dest = path.resolve(`${nested_file_deps_path}/nested_file.js`)
+      let expected_relative_path = path.relative(nested_file_deps_path, expected_source)
       expect(fs_mock.symlinkSync).to.be.calledWith(expected_relative_path, expected_dest)
     })
   })

--- a/lib/symdeps.test.js
+++ b/lib/symdeps.test.js
@@ -35,7 +35,7 @@ const config = {
   },
 }
 
-describe('symdeps', () => {
+describe('core', () => {
   before(() => symdeps(config))
 
   it('should create a symlink for simple dependency names', () => {
@@ -87,13 +87,31 @@ describe('symdeps', () => {
     expect(fs_mock.unlinkSync).to.be.calledOnce
     expect(fs_mock.unlinkSync).to.be.calledWith(path.resolve('public/existing_symlinks/existing_symlink'))
   })
+})
+
+describe('options', () => {
+  let optionsConfig
+
+  beforeEach(() => {
+    fs_mock.symlinkSync.resetHistory()
+    fs_mock.linkSync.resetHistory()
+    fs_mock.unlinkSync.resetHistory()
+    mkdirp_mock.sync.resetHistory()
+
+    optionsConfig = {
+      paths: {
+        'public/simple_deps': [ 'dep_one', 'dep_two' ],
+        'public/scoped_deps': [ '@domain/dep_one', '@domain/dep_two' ],
+        'public/nested_file_deps': [ 'dep_two/nested_dir/nested_file.js' ],
+      },
+    }
+  })
 
   it('should create hard links if indicated via config', () => {
-    config.hard = true
-    symdeps(config)
-    fs_mock.symlinkSync.reset()
+    optionsConfig.hard = true
+    symdeps(optionsConfig)
 
-    expect(fs_mock.linkSync).to.be.callCount(6)
+    expect(fs_mock.linkSync).to.be.callCount(5)
     expect(fs_mock.symlinkSync).to.not.be.called
   })
 })


### PR DESCRIPTION
This PR adds support for relative links (instead of absolute links, which is the default), and documents its usage. It also replaces our use of `.reset()` on `sinon` spies with `.resetHistory()`, as is the new convention (we were getting deprecation warnings).

Current behavior is that a symlink created in `/Users/agarzola/projects/my-project/js/build/libs/dep.min.js` would point to something like:
```
/Users/agarzola/projects/my-project/node_modules/dep-name/dist/dep.min.js
```

With the option implemented here, that symlink would use this path:
```
../../../node_modules/dep-name/dist/dep.min.js
```

Closes #22.