### PR TITLE
Don't use OS dependent path.sep

### DIFF
--- a/lib/symdeps.js
+++ b/lib/symdeps.js
@@ -19,7 +19,7 @@ module.exports = config => {
         source = config.absolute ? absolute_source : path.relative(relative_base, absolute_source)
         destination = path.resolve(
           dest_base,
-          directive.split(path.sep).reduce((result, segment, i, array) => {
+          directive.split('/').reduce((result, segment, i, array) => {
             return array.length - 1 === i ? segment : ''
           }, '')
         )


### PR DESCRIPTION
When this fine package is used on a machine with Windows as an OS, it throws an error whilst creating (sym)links.
See issue #52 for the full stack trace.

The problem is that the OS dependent `path.sep` is used to do some "magic" to strip a full path down to the filename only, splitting the path using the above mentioned `path.sep`.

On Windows this is the character `\` instead of `/` which is used in the rest of the OS universe (=POSIX). (See [https://nodejs.org/api/path.html#pathsep](https://nodejs.org/api/path.html#pathsep))

Since the paths that are being fed to the "magic" are (as shown in the README.md) will most probably _always_ use a `/` as a path separator, splitting on `path.sep` on Windows (which is a `\`) will not perform the split, leaving the Windows user with something that might be the start of The Apocalypse, but at least a "nasty" error and no theme resources.

This PR "simply" replaces `path.sep` with a hard-coded `/` so the split splits and the resources are linked/saved correctly.

After applying this PR to my chromatichq.com project the error about `symdeps` went away:
![image](https://user-images.githubusercontent.com/18569707/158330863-0207eb0d-c8b9-4438-bf54-e79e841f8a1e.png)
