### PR TITLE
Restore support for Node.js >=20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 20
+          - 21
           - 22
           - 23
           - 24

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/agarzola/symdeps#readme",
   "engines": {
-    "node": ">=22 <25"
+    "node": ">=20 <25"
   },
   "pre-push": [
     "test",


### PR DESCRIPTION
Node.js v20 is still supported, so there is no reason to drop support just yet.